### PR TITLE
return only relevant fields from server

### DIFF
--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,9 +1,8 @@
 import type { NextPage } from "next";
 import { createClient } from "next-sanity";
 import Head from "next/head";
-import Image from "next/image";
-import { Navigation, Headline, ContactGrid, Footer } from "../components";
-import styles from "../styles/Home.module.css";
+import { Navigation, ContactGrid, Footer } from "../components";
+import { fieldMask } from "../util";
 
 const client = createClient({
   projectId: "mam500cy",
@@ -34,21 +33,8 @@ const Home: NextPage<PageProps> = ({ links, contacts }) => {
         <meta name="description" content="Contact information" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <Navigation
-        links={links
-          .map((link) => ({ title: link.title, link: link.link }))
-          .reverse()}
-        currentPage="contact"
-      />
-      <ContactGrid
-        cards={contacts.map((contact) => ({
-          name: contact.name,
-          title: contact.title,
-          email: contact?.email,
-          tel: contact?.tel,
-          description: contact?.description,
-        }))}
-      />
+      <Navigation links={links.slice().reverse()} currentPage="contact" />
+      <ContactGrid cards={contacts} />
       <Footer />
     </div>
   );
@@ -61,8 +47,14 @@ export const getStaticProps = async () => {
   const contacts = await client.fetch(`*[_type == "contact"]`);
   return {
     props: {
-      links,
-      contacts,
+      links: fieldMask(links, ["title", "link"]),
+      contacts: fieldMask(contacts, [
+        "name",
+        "title",
+        "email",
+        "tel",
+        "description",
+      ]),
     },
     revalidate: 43200,
   };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,6 @@
 import type { NextPage } from "next";
 import { createClient } from "next-sanity";
 import Head from "next/head";
-import Image from "next/image";
 import { useEffect } from "react";
 import {
   Navigation,
@@ -11,6 +10,7 @@ import {
   Wishlist,
   Footer,
 } from "../components";
+import { fieldMask } from "../util";
 
 type PageProps = {
   infoText: {
@@ -46,12 +46,9 @@ const Home: NextPage<PageProps> = ({ infoText, headLine, links, events }) => {
       behavior: "smooth",
     });
   }, []);
+
   const timelineEvents = events
-    .map((event) => ({
-      name: event.name,
-      description: event.description,
-      time: event.time,
-    }))
+    .slice()
     .sort((a, b) => (a.time > b.time ? 1 : -1));
   const dayBefore = timelineEvents.find((ev) =>
     ev.name.includes("Dagen innan")
@@ -74,12 +71,7 @@ const Home: NextPage<PageProps> = ({ infoText, headLine, links, events }) => {
         <meta name="description" content="Valeris and Annes wedding website" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <Navigation
-        links={links
-          .map((link) => ({ title: link.title, link: link.link }))
-          .reverse()}
-        currentPage="/"
-      />
+      <Navigation links={links.slice().reverse()} currentPage="/" />
       <main>
         <Headline headLine={headLine[0].headline} />
         <Introduction
@@ -104,12 +96,13 @@ export const getStaticProps = async () => {
   const infoText = await client.fetch(`*[_type == "infoText"]`);
   const links = await client.fetch(`*[_type == "link"]`);
   const events = await client.fetch(`*[_type == "event"]`);
+
   return {
     props: {
-      headLine,
-      infoText,
-      links,
-      events,
+      headLine: fieldMask(headLine, ["headline"]),
+      infoText: fieldMask(infoText, ["title", "text", "type"]),
+      links: fieldMask(links, ["title", "link"]),
+      events: fieldMask(events, ["name", "time", "description"]),
     },
     revalidate: 43200,
   };

--- a/util.ts
+++ b/util.ts
@@ -1,0 +1,12 @@
+export const fieldMask = <T extends {}, K extends keyof T>(
+  obj: T,
+  mask: K[]
+): Pick<T, K> => {
+  const result = {} as Pick<T, K>;
+  for (const key of mask) {
+    if (key in obj) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+};


### PR DESCRIPTION
The prop types are currently lying. Handling filtering out of relevant fields on server. This makes client code simpler and makes the types tell the truth again